### PR TITLE
Move `ember-cli-babel` to `devDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,13 +24,13 @@
   "dependencies": {
     "browserstack": "^1.5.0",
     "browserstack-local": "^1.3.0",
-    "ember-cli-babel": "^6.6.0",
     "rsvp": "^4.7.0",
     "yargs": "^10.0.3"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
     "ember-cli": "~2.17.0",
+    "ember-cli-babel": "^6.6.0",
     "ember-cli-dependency-checker": "^2.0.0",
     "ember-cli-eslint": "^4.2.1",
     "ember-cli-htmlbars": "^2.0.1",


### PR DESCRIPTION
This addon does not have any JS files that need to be transpiled, so we can move the dependency to `devDependencies`

/cc @kategengler 