### PR TITLE
Bump min Node.js version to 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   # we recommend testing addons with the same minimum supported node version as Ember CLI
   # so that your addon works for all apps
-  - "4"
+  - "8"
 
 sudo: false
 dist: trusty
@@ -22,7 +22,8 @@ env:
     # we recommend new addons test the current and previous LTS
     # as well as latest stable release (bonus points to beta/canary)
     - EMBER_TRY_SCENARIO=ember-lts-2.12
-    - EMBER_TRY_SCENARIO=ember-lts-2.16
+    - EMBER_TRY_SCENARIO=ember-lts-3.0
+    - EMBER_TRY_SCENARIO=ember-lts-3.8
     - EMBER_TRY_SCENARIO=ember-release
     - EMBER_TRY_SCENARIO=ember-beta
     - EMBER_TRY_SCENARIO=ember-canary

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -11,10 +11,18 @@ module.exports = {
       }
     },
     {
-      name: 'ember-lts-2.16',
+      name: 'ember-lts-3.0',
       npm: {
         devDependencies: {
-          'ember-source': '~2.16.0'
+          'ember-source': '~3.0.0'
+        }
+      }
+    },
+    {
+      name: 'ember-lts-3.8',
+      npm: {
+        devDependencies: {
+          'ember-source': '~3.8.0'
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "loader.js": "^4.2.3"
   },
   "engines": {
-    "node": "^4.5 || 6.* || >= 7.*"
+    "node": "8.* || >= 10.*"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
It would hopefully fix the linting job in CI.

Very small PR, I'm almost confused for the noise 😉