### PR TITLE
Add easier support for GitHub Actions

### DIFF
--- a/lib/utils/build-name-from-env.js
+++ b/lib/utils/build-name-from-env.js
@@ -1,7 +1,7 @@
 const crypto = require('crypto');
 
 module.exports = function() {
-  let buildNum = process.env.TRAVIS_JOB_NUMBER || process.env.BITBUCKET_BUILD_NUMBER || process.env.CIRCLE_BUILD_NUM || process.env.CI_JOB_ID;
+  let buildNum = process.env.TRAVIS_JOB_NUMBER || process.env.BITBUCKET_BUILD_NUMBER || process.env.CIRCLE_BUILD_NUM || process.env.GITHUB_RUN_ID || process.env.CI_JOB_ID;
   let prefix = process.env.BROWSERSTACK_BUILD_NAME_PREFIX;
   if (buildNum && prefix) {
     return prefix + '_' + buildNum;


### PR DESCRIPTION
Add `process.env.GITHUB_RUN_ID` as a default build number fallback to allow GitHub Actions to work out of the box.

See https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables for documentation on environment variables.

