### PR TITLE
fix(connect): fix pid file creation for newer versions of node

### DIFF
--- a/lib/tasks/start-browserstack-tunnel.js
+++ b/lib/tasks/start-browserstack-tunnel.js
@@ -30,5 +30,5 @@ module.exports = function(ui) {
 
 function writePidFile(pid) {
   let pidFile = 'browserstack-local.pid';
-  fs.writeFileSync(pidFile, pid);
+  fs.writeFileSync(pidFile, String(pid));
 }


### PR DESCRIPTION
With newer versions of node (in our case LTS 14) `fs.writeFileSync`
throws an error when passing a number as `data` argument. `bsLocal.pid`
is a number so we need to cast it to a string in order to fix the error.