### PR TITLE
Separate the concepts of build name and local identifier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
       BROWSERSTACK_ACCESS_KEY: aeqUXusvriNdmYFQpbrj
       # The following is necessary when using browserstack under matrix builds on Github Actions
       # The Job ID + Run ID isn't unique across matrix runs and will fail when run simultaneously
-      BROWSERSTACK_BUILD_NAME_PREFIX: ${{ matrix.node-version }}
+      BROWSERSTACK_LOCAL_ID_SUFFIX: ${{ matrix.node-version }}
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 Facilitates automated testing using BrowserStack with ember-cli projects
 
-As of October 21, 2019, version 0.0.8 is the minimum version that will work with BrowserStack, due to API host changes. 
-
 ## Commands
 
 ### `ember browserstack:connect`
@@ -45,28 +43,22 @@ As of October 21, 2019, version 0.0.8 is the minimum version that will work with
       'Chrome'
     ]
     ```
-    To see available options, run `npx browserstack-launch --help`, with more info about what those options do available here: https://www.browserstack.com/automate/capabilities and https://github.com/scottgonzalez/node-browserstack#browser-objects
+    To see available options run `npx ember-cli-browserstack --help` or see https://www.browserstack.com/automate/capabilities and https://github.com/scottgonzalez/node-browserstack#browser-objects
     Not all options are required.
 1. Open a tunnel to BrowserStack using `ember browserstack:connect`.
 
     This will create a `browserstack-local.pid` file, necessary for later disconnecting the tunnel.
 1. Run tests (`ember test`)
-    You may need to specify `--host 127.0.0.1` to support Safari
+    You may need to specify `--host 127.0.0.1` and `--test-port=7774` to support Safari
 1. When tests are complete, close the tunnel to BrowserStack using `ember browserstack:disconnect`
-
-## Running on TravisCI
-
-When running on TravisCI, this addon will use the `TRAVIS_JOB_NUMBER` environment variable to group the browsers run in that job.
-There is a helper command `ember browserstack:results` that will return links to each of the test runs in BrowserStack.
-
-## Running on Bitbucket Pipelines
-
-When running on Bitbucket Pipelines, this addon will use the `BITBUCKET_BUILD_NUMBER` environment variable to group the browsers run in that job.
-There is a helper command `ember browserstack:results` that will return links to each of the test runs in BrowserStack.
 
 ## Build name
 
-The above will be prefixed with the env var BROWSERSTACK_BUILD_NAME_PREFIX, if set.
+The build name can be set by passing it to each launcher (`--build`) or by setting the environment variable `BROWSERSTACK_BUILD_NAME`.
+If no build name is passed it will be [determined by CI Environment variables](https://github.com/kategengler/ember-cli-browserstack/blob/main/lib/utils/build-name-from-env.js), falling back to a random value.
+The build name can be prefixed by setting `BROWSERSTACK_BUILD_NAME_PREFIX`.
+
+The name is used for grouping runs in the BrowserStack UI and to fetch results.
 
 ## Configuring Browserstack `local identifier`
 
@@ -74,6 +66,10 @@ _In most cases you don't need to do anything with default setup._
 _However if you are building custom matrix build CI pipeline, then you need to tell Browserstack where each instance is for its routing to work._
 
 In case you need to setup custom value for `local identifier`, you can set `BROWSERSTACK_LOCAL_IDENTIFIER` env var.
+If the env var is not set, this addon attempts to set a smart value for the local identifier based on the build name.
+You can append to this smart value by setting `BROWSERSTACK_LOCAL_ID_SUFFIX`.
+
+See, for example, the GitHub Actions setup in this repository.
 
 _See for more information: https://www.browserstack.com/local-testing/automate#multiple-local-testing-connections_
 

--- a/lib/tasks/launch-browserstack-browser.js
+++ b/lib/tasks/launch-browserstack-browser.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 /* eslint-disable no-console, no-process-exit */
 const buildNameFromEnv = require('../utils/build-name-from-env');
+const localIdentifier = require('../utils/local-identifier');
 
 let build = buildNameFromEnv();
 
@@ -48,7 +49,7 @@ let argv = require('yargs')
   })
   .option('build', {
     describe:
-      'Build Name, defaults to process.env.TRAVIS_JOB_NUMBER or process.env.BITBUCKET_BUILD_NUMBER, if set, prefixed with process.env.BROWSERSTACK_BUILD_NAME_PREFIX, if set. Defaults to random string.',
+      'Build Name, defaults to values from CI environment if set. Defaults to random string.',
     default: build,
   })
   .option('project', {
@@ -104,7 +105,7 @@ let settings = {
   project: argv.project,
 };
 
-settings.localIdentifier = process.env.BROWSERSTACK_LOCAL_IDENTIFIER || build;
+settings.localIdentifier = localIdentifier();
 
 for (let i in settings) {
   if (!settings[i]) {

--- a/lib/tasks/start-browserstack-tunnel.js
+++ b/lib/tasks/start-browserstack-tunnel.js
@@ -1,6 +1,6 @@
 const RSVP = require('rsvp');
 const fs = require('fs');
-const buildNameFromEnv = require('../utils/build-name-from-env');
+const localIdentifier = require('../utils/local-identifier');
 
 module.exports = function (ui) {
   let browserstackLocal = require('browserstack-local');
@@ -11,8 +11,7 @@ module.exports = function (ui) {
     force: true,
   };
 
-  options.localIdentifier =
-    process.env.BROWSERSTACK_LOCAL_IDENTIFIER || buildNameFromEnv();
+  options.localIdentifier = localIdentifier();
 
   let bsLocal = new browserstackLocal.Local();
 

--- a/lib/utils/build-name-from-env.js
+++ b/lib/utils/build-name-from-env.js
@@ -1,18 +1,35 @@
 const crypto = require('crypto');
 
 module.exports = function () {
-  let buildNum =
+  let buildDesc =
+    process.env.BROWSERSTACK_BUILD_NAME ||
     process.env.TRAVIS_JOB_NUMBER ||
     process.env.BITBUCKET_BUILD_NUMBER ||
     process.env.CIRCLE_BUILD_NUM ||
-    process.env.GITHUB_RUN_ID ||
-    process.env.CI_JOB_ID;
-  if (process.env.GITHUB_RUN_ID) {
-    buildNum = `${buildNum}${process.env.GITHUB_JOB}`;
-  }
+    buildNameForGithubActions() ||
+    process.env.CI_JOB_ID ||
+    crypto.randomBytes(10).toString('hex');
+
   let prefix = process.env.BROWSERSTACK_BUILD_NAME_PREFIX;
-  if (buildNum && prefix) {
-    return prefix + '_' + buildNum;
+  if (buildDesc && prefix) {
+    return `${prefix}_${buildDesc}`;
   }
-  return buildNum || crypto.randomBytes(10).toString('hex');
+  return buildDesc;
 };
+
+function buildNameForGithubActions() {
+  if (process.env.GITHUB_RUN_ID) {
+    let runDesc = githubRunDesc();
+    return `${runDesc}_${process.env.GITHUB_WORKFLOW}_${process.env.GITHUB_RUN_ID}_${process.env.GITHUB_JOB}`;
+  }
+}
+
+function githubRunDesc() {
+  if (process.env.GITHUB_HEAD_REF) {
+    let matches = /(\d+)/.exec(process.env.GITHUB_REF);
+    let pr = matches[1];
+    return `PR_${pr}`;
+  } else {
+    return process.env.GITHUB_REF.replace('refs/heads/', '');
+  }
+}

--- a/lib/utils/local-identifier.js
+++ b/lib/utils/local-identifier.js
@@ -1,0 +1,10 @@
+const buildNameFromEnv = require('../utils/build-name-from-env');
+
+module.exports = function () {
+  let envId = process.env.BROWSERSTACK_LOCAL_IDENTIFIER;
+  if (envId) {
+    return envId;
+  }
+  let envIdSuffix = process.env.BROWSERSTACK_LOCAL_ID_SUFFIX || '';
+  return `${buildNameFromEnv()}${envIdSuffix}`;
+};

--- a/node-tests/utils/build-name-from-env-test.js
+++ b/node-tests/utils/build-name-from-env-test.js
@@ -24,34 +24,40 @@ describe('buildNameFromEnv', function () {
   });
 
   it('builds a build name from GitHub Actions env vars', async function () {
-    process.env.GITHUB_RUN_ID = '212';
-    process.env.GITHUB_REF = 'refs/heads/feature-branch-1';
-    process.env.GITHUB_WORKFLOW = 'ci';
-    process.env.GITHUB_JOB = 'test';
+    // Can only be tested not under GitHub Actions
+    if (!process.env.CI) {
+      process.env.GITHUB_RUN_ID = '212';
+      process.env.GITHUB_REF = 'refs/heads/feature-branch-1';
+      process.env.GITHUB_WORKFLOW = 'ci';
+      process.env.GITHUB_JOB = 'test';
 
-    let result = buildNameFromEnv();
-    assert.equal(result, 'feature-branch-1_ci_212_test');
+      let result = buildNameFromEnv();
+      assert.equal(result, 'feature-branch-1_ci_212_test');
 
-    delete process.env.GITHUB_RUN_ID;
-    delete process.env.GITHUB_REF;
-    delete process.env.GITHUB_WORKFLOW;
-    delete process.env.GITHUB_JOB;
+      delete process.env.GITHUB_RUN_ID;
+      delete process.env.GITHUB_REF;
+      delete process.env.GITHUB_WORKFLOW;
+      delete process.env.GITHUB_JOB;
+    }
   });
 
   it('builds a build name from GitHub Actions env vars in a pull request', async function () {
-    process.env.GITHUB_RUN_ID = '212';
-    process.env.GITHUB_REF = 'refs/pulls/123/merge';
-    process.env.GITHUB_HEAD_REF = 'refs/heads/feature-branch-1';
-    process.env.GITHUB_WORKFLOW = 'ci';
-    process.env.GITHUB_JOB = 'test';
+    // Can only be tested not under GitHub Actions
+    if (!process.env.CI) {
+      process.env.GITHUB_RUN_ID = '212';
+      process.env.GITHUB_REF = 'refs/pulls/123/merge';
+      process.env.GITHUB_HEAD_REF = 'refs/heads/feature-branch-1';
+      process.env.GITHUB_WORKFLOW = 'ci';
+      process.env.GITHUB_JOB = 'test';
 
-    let result = buildNameFromEnv();
-    assert.equal(result, 'PR_123_ci_212_test');
+      let result = buildNameFromEnv();
+      assert.equal(result, 'PR_123_ci_212_test');
 
-    delete process.env.GITHUB_RUN_ID;
-    delete process.env.GITHUB_REF;
-    delete process.env.GITHUB_HEAD_REF;
-    delete process.env.GITHUB_WORKFLOW;
-    delete process.env.GITHUB_JOB;
+      delete process.env.GITHUB_RUN_ID;
+      delete process.env.GITHUB_REF;
+      delete process.env.GITHUB_HEAD_REF;
+      delete process.env.GITHUB_WORKFLOW;
+      delete process.env.GITHUB_JOB;
+    }
   });
 });

--- a/node-tests/utils/build-name-from-env-test.js
+++ b/node-tests/utils/build-name-from-env-test.js
@@ -1,0 +1,57 @@
+const { assert } = require('chai');
+const buildNameFromEnv = require('../../lib/utils/build-name-from-env');
+
+describe('buildNameFromEnv', function () {
+  it('defaults to random crypto when no env vars', async function () {
+    let result = buildNameFromEnv();
+    assert.ok(result.length, 'returns random');
+  });
+
+  it('prefixes build name when BROWSERSTACK_BUILD_NAME_PREFIX is set', async function () {
+    process.env.BROWSERSTACK_BUILD_NAME_PREFIX = 'foobar';
+    let result = buildNameFromEnv();
+    assert.match(result, /foobar/, 'build name is prefixed');
+
+    delete process.env.BROWSERSTACK_BUILD_NAME_PREFIX;
+  });
+
+  it('uses BROWSERSTACK_BUILD_NAME if set', async function () {
+    process.env.BROWSERSTACK_BUILD_NAME = 'nope';
+    let result = buildNameFromEnv();
+    assert.equal(result, 'nope');
+
+    delete process.env.BROWSERSTACK_BUILD_NAME;
+  });
+
+  it('builds a build name from GitHub Actions env vars', async function () {
+    process.env.GITHUB_RUN_ID = '212';
+    process.env.GITHUB_REF = 'refs/heads/feature-branch-1';
+    process.env.GITHUB_WORKFLOW = 'ci';
+    process.env.GITHUB_JOB = 'test';
+
+    let result = buildNameFromEnv();
+    assert.equal(result, 'feature-branch-1_ci_212_test');
+
+    delete process.env.GITHUB_RUN_ID;
+    delete process.env.GITHUB_REF;
+    delete process.env.GITHUB_WORKFLOW;
+    delete process.env.GITHUB_JOB;
+  });
+
+  it('builds a build name from GitHub Actions env vars in a pull request', async function () {
+    process.env.GITHUB_RUN_ID = '212';
+    process.env.GITHUB_REF = 'refs/pulls/123/merge';
+    process.env.GITHUB_HEAD_REF = 'refs/heads/feature-branch-1';
+    process.env.GITHUB_WORKFLOW = 'ci';
+    process.env.GITHUB_JOB = 'test';
+
+    let result = buildNameFromEnv();
+    assert.equal(result, 'PR_123_ci_212_test');
+
+    delete process.env.GITHUB_RUN_ID;
+    delete process.env.GITHUB_REF;
+    delete process.env.GITHUB_HEAD_REF;
+    delete process.env.GITHUB_WORKFLOW;
+    delete process.env.GITHUB_JOB;
+  });
+});

--- a/node-tests/utils/local-identifier-test.js
+++ b/node-tests/utils/local-identifier-test.js
@@ -1,0 +1,30 @@
+const { assert } = require('chai');
+const localIdentifier = require('../../lib/utils/local-identifier');
+
+describe('localIdentifier', function () {
+  it('use BROWSERSTACK_LOCAL_IDENTIFIER if set', async function () {
+    process.env.BROWSERSTACK_LOCAL_IDENTIFIER = 'yep123';
+    let result = localIdentifier();
+    assert.equal(result, 'yep123', 'Uses overriding env var');
+
+    delete process.env.BROWSERSTACK_LOCAL_IDENTIFIER;
+  });
+
+  it('defaults to using buildName', async function () {
+    process.env.BROWSERSTACK_BUILD_NAME = 'nope';
+    let result = localIdentifier();
+    assert.equal(result, 'nope');
+
+    delete process.env.BROWSERSTACK_BUILD_NAME;
+  });
+
+  it('adds a suffix if env var is set', async function () {
+    process.env.BROWSERSTACK_BUILD_NAME = 'nope';
+    process.env.BROWSERSTACK_LOCAL_ID_SUFFIX = '129';
+    let result = localIdentifier();
+    assert.equal(result, 'nope129');
+
+    delete process.env.BROWSERSTACK_BUILD_NAME;
+    delete process.env.BROWSERSTACK_LOCAL_ID_SUFFIX;
+  });
+});


### PR DESCRIPTION
Local identifier will still default to the build name, but they can be
set entirely separately.

Default build names for GitHub Actions are more descriptive

Adds an env var to replace the build name instead of passing or allowing it to be build `BROWSERSTACK_BUILD_NAME` 

Adds an env var to suffix the localIdentifier `BROWSERSTACK_LOCAL_ID_SUFFIX`, that allows matrix builds to suffix with say, the matrix variable, to have a unique local id rather than have to completely override `BROWSERSTACK_LOCAL_IDENTIFIER`.

`BROWSERSTACK_BUILD_NAME_PREFIX` will now always be prefixed to a addon-determined build name.