### PR TITLE
Replace spaces in github workflow name

### DIFF
--- a/lib/utils/build-name-from-env.js
+++ b/lib/utils/build-name-from-env.js
@@ -20,7 +20,8 @@ module.exports = function () {
 function buildNameForGithubActions() {
   if (process.env.GITHUB_RUN_ID) {
     let runDesc = githubRunDesc();
-    return `${runDesc}_${process.env.GITHUB_WORKFLOW}_${process.env.GITHUB_RUN_ID}_${process.env.GITHUB_JOB}`;
+    let workflow = process.env.GITHUB_WORKFLOW.replace(/\s/g, '_');
+    return `${runDesc}_${workflow}_${process.env.GITHUB_RUN_ID}_${process.env.GITHUB_JOB}`;
   }
 }
 

--- a/node-tests/utils/build-name-from-env-test.js
+++ b/node-tests/utils/build-name-from-env-test.js
@@ -60,4 +60,22 @@ describe('buildNameFromEnv', function () {
       delete process.env.GITHUB_JOB;
     }
   });
+
+  it('replaces spaces in workflow name', async function () {
+    // Can only be tested not under GitHub Actions
+    if (!process.env.CI) {
+      process.env.GITHUB_RUN_ID = '212';
+      process.env.GITHUB_REF = 'refs/heads/feature-branch-1';
+      process.env.GITHUB_WORKFLOW = 'spacey ci';
+      process.env.GITHUB_JOB = 'test';
+
+      let result = buildNameFromEnv();
+      assert.equal(result, 'feature-branch-1_spacey_ci_212_test');
+
+      delete process.env.GITHUB_RUN_ID;
+      delete process.env.GITHUB_REF;
+      delete process.env.GITHUB_WORKFLOW;
+      delete process.env.GITHUB_JOB;
+    }
+  });
 });


### PR DESCRIPTION
GITHUB_WORKFLOW  uses the user specified name of the workflow which can
contain spaces, but those aren't allowed by browserstack.