### PR TITLE
Handle Events With PR as Ref

### DIFF
--- a/lib/utils/build-name-from-env.js
+++ b/lib/utils/build-name-from-env.js
@@ -43,6 +43,10 @@ function githubRunDesc(ref, headRef) {
     let matches = /(\d+)/.exec(ref);
     let pr = matches[1];
     return `PR_${pr}`;
+  } else if (ref.includes('refs/pull/')) {
+    let matches = /(\d+)/.exec(ref);
+    let pr = matches[1];
+    return `PR_${pr}`;
   } else {
     return ref.replace('refs/heads/', '').replace('refs/tags/', '');
   }

--- a/node-tests/utils/build-name-from-env-test.js
+++ b/node-tests/utils/build-name-from-env-test.js
@@ -61,6 +61,11 @@ describe('buildNameFromEnv', function () {
       let result = buildNameFromEnv._githubRunDesc('refs/tags/v1.0.0');
       assert.equal(result, 'v1.0.0');
     });
+
+    it('uses the pr number when headRef is not set', async function () {
+      let result = buildNameFromEnv._githubRunDesc('refs/pull/123/merge');
+      assert.equal(result, 'PR_123');
+    });
   });
 
   describe('_buildNameForGithubActions', function () {


### PR DESCRIPTION
Some events, such as pull request review, don't send $GITHUB_HEAD_REF. Instead the ref contains the PR merge and the PR number has to be extracted from it.